### PR TITLE
fix large precision masking

### DIFF
--- a/Source/Meio.Mask.Reverse.js
+++ b/Source/Meio.Mask.Reverse.js
@@ -154,7 +154,9 @@ Meio.Mask.Reverse = new Class({
 
 	maskThousands: function(str){
 		if (this.options.thousands){
-			while (this.reThousands.test(str)) str = str.replace(this.reThousands, this.thousandsReplaceStr);
+			while (str.toFloat() >= 1000 && this.reThousands.test(str)) {
+				str = str.replace(this.reThousands, this.thousandsReplaceStr);
+			}
 		}
 		return str;
 	},


### PR DESCRIPTION
Current version is failing in this tests:

test('should apply a precision: 5 mask to the 0 string', function(){
    equals('0'.meiomask('Reverse', 'Decimal', { precision: 5 }), '0,00000');
});

test('should apply a precision: 5 mask to the 1 string', function(){
    equals('1'.meiomask('Reverse', 'Decimal', { precision: 5 }), '1,00000');
});

test('should apply a precision: 5 mask to the 1000 string', function(){
    equals('1000'.meiomask('Reverse', 'Decimal', { precision: 5 }), '1.000,00000');
});

test('should apply a precision: 5 mask to the 0.001 string', function(){
    equals('0.001'.meiomask('Reverse', 'Decimal', { precision: 5 }), '0,00100');
});
