### PR TITLE
Add IntegerUs for Reverse

### DIFF
--- a/Source/Meio.Mask.Reverse.js
+++ b/Source/Meio.Mask.Reverse.js
@@ -171,6 +171,7 @@ Meio.Mask.Reverse = new Class({
 
 Meio.Mask.createMasks('Reverse', {
 	'Integer'		: {precision: 0, maxLength: 18},
+	'IntegerUs'		: {precision: 0, maxLength: 18, thousands: ',', decimal: '.'},
 	'Decimal'		: { },
 	'DecimalUs'		: {thousands: ',', decimal: '.'},
 	'Reais'			: {symbol: 'R$ ' },


### PR DESCRIPTION
IntegerUs! Yes, why not?! There's already a DecimalUs there... Also, using data-meiomask-option isn't easily feasible in a xslt file (parser thinks its an attribute value template). A possible fix is to assume that the value of the meiomask-option is an object body, but it will break everything :P
