### PR TITLE
Update Source/Meio.Mask.js

### DIFF
--- a/Source/Meio.Mask.js
+++ b/Source/Meio.Mask.js
@@ -154,7 +154,7 @@ provides: [Meio.Mask]
         blur: function(e, o){
             var element = this.element;
             if (e && element.retrieve('meiomask:focusvalue') != element.get('value')){
-                element.fireEvent('change');
+                element.fireEvent('change', e);
             }
         },
 


### PR DESCRIPTION
Forwarding `changeEvent` at `fireEvent("change")`. IMHO it's the expected behavior, since:

``` javascript
$$("input").each( function(input){
    input.addEvent( "change", function(ev) {
        console.log("event object is:", ev);
    } );

    input.meiomask( input.get('data-meiomask'), JSON.decode( input.get('data-meiomask-options') ) );
} );
```

was logging: `event object is: undefined`
